### PR TITLE
[NNC] enable fusion of linear with elementwise OP

### DIFF
--- a/aten/src/ATen/native/mkldnn/Common.h
+++ b/aten/src/ATen/native/mkldnn/Common.h
@@ -39,6 +39,22 @@ struct ContextConv final {
         attr_(attr) {}
 };
 
+struct ContextLinear final {
+  ideep::tensor weight_packed_;
+  c10::optional<at::Tensor> at_bias_;
+  ideep::attr_t attr_;
+
+  ContextLinear() = delete;
+
+  ContextLinear(
+      ideep::tensor&& weight_packed,
+      c10::optional<at::Tensor> at_bias,
+      ideep::attr_t attr)
+      : weight_packed_(std::move(weight_packed)),
+        at_bias_(std::move(at_bias)),
+        attr_(attr) {}
+};
+
 } // namespace mkldnn
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/mkldnn/LinearPrepack.cpp
+++ b/aten/src/ATen/native/mkldnn/LinearPrepack.cpp
@@ -125,6 +125,50 @@ Tensor run(ContextLinear& context, const Tensor& input) {
   return output;
 }
 
+void _mkldnn_linear_out(
+    const ideep::tensor& x,
+    ideep::tensor& y,
+    const ideep::tensor& w,
+    const c10::optional<ideep::tensor>& b,
+    const ideep::attr_t& attr = ideep::attr_t()) {
+  if (b.has_value()) {
+    ideep::inner_product_forward::compute(
+        x,
+        w,
+        b.value(),
+        y,
+        ideep::scale_t(),
+        ideep::scale_t(),
+        ideep::scale_t(),
+        attr);
+  } else {
+    ideep::inner_product_forward::compute(
+        x, w, y, ideep::scale_t(), ideep::scale_t(), ideep::scale_t(), attr);
+  }
+}
+
+void mkldnn_linear_out(
+    const Tensor& input,
+    ideep::tensor& mkldnn_output,
+    const ideep::tensor& mkldnn_weight,
+    const c10::optional<Tensor>& bias_opt,
+    const ideep::attr_t& attr = ideep::attr_t()) {
+  c10::MaybeOwned<Tensor> bias_maybe_owned =
+      at::borrow_from_optional_tensor(bias_opt);
+  const Tensor& bias = *bias_maybe_owned;
+
+  c10::impl::ExcludeDispatchKeyGuard edkg(c10::autograd_dispatch_keyset);
+  const ideep::tensor mkldnn_input = itensor_view_from_dense(input);
+
+  c10::optional<ideep::tensor> mkldnn_bias{c10::nullopt};
+  if (bias.defined()) {
+    mkldnn_bias = itensor_from_tensor(bias);
+  }
+
+  _mkldnn_linear_out(
+      mkldnn_input, mkldnn_output, mkldnn_weight, mkldnn_bias, attr);
+}
+
 void run(ContextLinear& context, const Tensor& input, void* output) {
   const ideep::tensor& mkldnn_weight = context.weight_packed_;
 
@@ -136,52 +180,20 @@ void run(ContextLinear& context, const Tensor& input, void* output) {
 
   std::vector<int64_t> output_size(input_size.begin(), input_size.end() - 1);
   output_size.push_back(mkldnn_weight.get_dim(0));
-  // auto output = at::empty(output_size, input.options());
 
   std::vector<int64_t> output_size_reshaped = {
       input_reshaped.size(0), mkldnn_weight.get_dim(0)};
-  // output = output.reshape(output_size_reshaped);
-
-  c10::impl::ExcludeDispatchKeyGuard edkg(c10::autograd_dispatch_keyset);
-  const ideep::tensor mkldnn_input = itensor_view_from_dense(input_reshaped);
 
   ideep::tensor::desc o_desc = {
-      output_size_reshaped, mkldnn_input.get_data_type()};
+      output_size_reshaped, get_mkldnn_dtype(input.scalar_type())};
   ideep::tensor mkldnn_output = {o_desc, output};
 
-  // ideep::tensor mkldnn_output = itensor_view_from_dense(output);
-
-  c10::MaybeOwned<Tensor> bias_maybe_owned =
-      at::borrow_from_optional_tensor(context.at_bias_);
-  const Tensor& bias = *bias_maybe_owned;
-
-  if (bias.defined()) {
-    const ideep::tensor mkldnn_bias = itensor_view_from_dense(bias);
-    ideep::inner_product_forward::compute(
-        mkldnn_input,
-        mkldnn_weight,
-        mkldnn_bias,
-        mkldnn_output,
-        ideep::scale_t(),
-        ideep::scale_t(),
-        ideep::scale_t(),
-        context.attr_);
-  } else {
-    ideep::inner_product_forward::compute(
-        mkldnn_input,
-        mkldnn_weight,
-        mkldnn_output,
-        ideep::scale_t(),
-        ideep::scale_t(),
-        ideep::scale_t(),
-        context.attr_);
-  }
-
-  // if (dim != 2) {
-  //   output = output.reshape(output_size);
-  // }
-
-  // return output;
+  mkldnn_linear_out(
+      input_reshaped,
+      mkldnn_output,
+      mkldnn_weight,
+      context.at_bias_,
+      context.attr_);
 }
 
 Tensor linear_run(

--- a/aten/src/ATen/native/mkldnn/LinearPrepack.cpp
+++ b/aten/src/ATen/native/mkldnn/LinearPrepack.cpp
@@ -1,0 +1,140 @@
+#include <vector>
+
+#include <ATen/native/mkldnn/Common.h>
+#include <ATen/native/mkldnn/LinearPrepack.h>
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
+#include <ATen/native/utils/Factory.h>
+#include <ATen/native/utils/ParamUtils.h>
+#include <c10/util/irange.h>
+#include <torch/csrc/jit/passes/mkldnn_rewrite.h>
+
+#if AT_MKLDNN_ENABLED()
+
+namespace at {
+namespace native {
+namespace mkldnn {
+namespace internal {
+namespace linear {
+
+using namespace torch::jit::mkldnn;
+
+c10::intrusive_ptr<mkldnn::LinearOpContext> createLinearPrePackOpContext(
+    Tensor weight,
+    c10::optional<Tensor> bias,
+    std::vector<int64_t> input_size,
+    std::string attr,
+    std::vector<c10::optional<at::Scalar>> scalars,
+    c10::optional<std::string> algorithm) {
+  auto it = fusion_attr_map().find(attr);
+  TORCH_CHECK(it != fusion_attr_map().end(), "Fusion behavior undefined.");
+  ideep::attr_t op_attr = it->second.attr_function(scalars, algorithm);
+  return mkldnn::MkldnnLinearOpContext::create_context(
+      std::move(weight), std::move(bias), std::move(input_size), op_attr);
+}
+
+ContextLinear create(
+    const Tensor& weight,
+    const c10::optional<Tensor>& bias,
+    const IntArrayRef input_size,
+    const ideep::attr_t& attr) {
+  c10::impl::ExcludeDispatchKeyGuard edkg(c10::autograd_dispatch_keyset);
+  ideep::tensor w = itensor_view_from_dense(weight);
+  auto dtype = w.get_data_type();
+
+  int64_t b_size = std::accumulate(
+                       input_size.begin(),
+                       input_size.end(),
+                       (int64_t)1,
+                       std::multiplies<int64_t>()) /
+      input_size[input_size.size() - 1];
+
+  auto out_features = weight.size(0);
+  auto in_features = weight.size(1);
+  ideep::dims reshaped_input_size = {b_size, in_features};
+
+  ideep::tensor::desc expected_weight_desc =
+      ideep::inner_product_forward::expected_weights_desc(
+          {out_features, in_features},
+          reshaped_input_size,
+          /* w_dtype */ dtype,
+          /* x_dtype */ dtype);
+
+  ideep::tensor packed_weight;
+  packed_weight.init(expected_weight_desc);
+  packed_weight.feed_from(w);
+
+  return ContextLinear{
+      std::move(packed_weight),
+      bias.has_value() ? c10::make_optional(*bias) : c10::nullopt,
+      std::move(attr)};
+}
+
+Tensor run(ContextLinear& context, const Tensor& input) {
+  const ideep::tensor& mkldnn_weight = context.weight_packed_;
+
+  auto input_size = input.sizes();
+
+  const int64_t dim = input.dim();
+  auto input_reshaped =
+      dim == 2 ? input : input.reshape({-1, input.size(input.dim() - 1)});
+
+  std::vector<int64_t> output_size(input_size.begin(), input_size.end() - 1);
+  output_size.push_back(mkldnn_weight.get_dim(0));
+  auto output = at::empty(output_size, input.options());
+
+  if (dim != 2) {
+    std::vector<int64_t> output_size_reshaped = {
+        input_reshaped.size(0), mkldnn_weight.get_dim(0)};
+    output = output.reshape(output_size_reshaped);
+  }
+
+  c10::impl::ExcludeDispatchKeyGuard edkg(c10::autograd_dispatch_keyset);
+  const ideep::tensor mkldnn_input = itensor_view_from_dense(input_reshaped);
+  ideep::tensor mkldnn_output = itensor_view_from_dense(output);
+
+  c10::MaybeOwned<Tensor> bias_maybe_owned =
+      at::borrow_from_optional_tensor(context.at_bias_);
+  const Tensor& bias = *bias_maybe_owned;
+
+  if (bias.defined()) {
+    const ideep::tensor mkldnn_bias = itensor_view_from_dense(bias);
+    ideep::inner_product_forward::compute(
+        mkldnn_input,
+        mkldnn_weight,
+        mkldnn_bias,
+        mkldnn_output,
+        ideep::scale_t(),
+        ideep::scale_t(),
+        ideep::scale_t(),
+        context.attr_);
+  } else {
+    ideep::inner_product_forward::compute(
+        mkldnn_input,
+        mkldnn_weight,
+        mkldnn_output,
+        ideep::scale_t(),
+        ideep::scale_t(),
+        ideep::scale_t(),
+        context.attr_);
+  }
+
+  if (dim != 2) {
+    output = output.reshape(output_size);
+  }
+
+  return output;
+}
+
+Tensor linear_run(
+    const Tensor& input,
+    const c10::intrusive_ptr<mkldnn::LinearOpContext>& op_context) {
+  return op_context->run(input);
+}
+
+} // namespace linear
+} // namespace internal
+} // namespace mkldnn
+} // namespace native
+} // namespace at
+
+#endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/mkldnn/LinearPrepack.h
+++ b/aten/src/ATen/native/mkldnn/LinearPrepack.h
@@ -32,6 +32,8 @@ ContextLinear create(
 
 Tensor run(ContextLinear& context, const Tensor& input);
 
+void run(ContextLinear& context, const Tensor& input, void* output);
+
 } // namespace linear
 } // namespace internal
 } // namespace mkldnn

--- a/aten/src/ATen/native/mkldnn/LinearPrepack.h
+++ b/aten/src/ATen/native/mkldnn/LinearPrepack.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <ATen/Tensor.h>
+#include <ATen/native/mkldnn/Common.h>
+#include <ATen/native/mkldnn/OpContext.h>
+
+#if AT_MKLDNN_ENABLED()
+
+namespace at {
+namespace native {
+namespace mkldnn {
+namespace internal {
+namespace linear {
+
+c10::intrusive_ptr<mkldnn::LinearOpContext> createLinearPrePackOpContext(
+    Tensor weight,
+    c10::optional<Tensor> bias,
+    std::vector<int64_t> input_size,
+    std::string attr,
+    std::vector<c10::optional<at::Scalar>> scalars,
+    c10::optional<std::string> algorithm);
+
+Tensor linear_run(
+    const Tensor& input,
+    const c10::intrusive_ptr<mkldnn::LinearOpContext>& op_context);
+
+ContextLinear create(
+    const Tensor& weight,
+    const c10::optional<Tensor>& bias,
+    const IntArrayRef input_size,
+    const ideep::attr_t& attr);
+
+Tensor run(ContextLinear& context, const Tensor& input);
+
+} // namespace linear
+} // namespace internal
+} // namespace mkldnn
+} // namespace native
+} // namespace at
+
+#endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/mkldnn/OpContext.cpp
+++ b/aten/src/ATen/native/mkldnn/OpContext.cpp
@@ -62,6 +62,10 @@ Tensor MkldnnLinearOpContext::run(const Tensor& input) {
   return mkldnn::internal::linear::run(op_context_, input);
 }
 
+void MkldnnLinearOpContext::run(const Tensor& input, void* output) {
+  return mkldnn::internal::linear::run(op_context_, input, output);
+}
+
 } // namespace mkldnn
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/mkldnn/OpContext.cpp
+++ b/aten/src/ATen/native/mkldnn/OpContext.cpp
@@ -1,4 +1,5 @@
 #include <ATen/native/mkldnn/ConvPrepack.h>
+#include <ATen/native/mkldnn/LinearPrepack.h>
 #include <ATen/native/mkldnn/OpContext.h>
 
 #if AT_MKLDNN_ENABLED()
@@ -38,6 +39,27 @@ Tensor MkldnnConvOpContext::run(const Tensor& input) {
 
 void MkldnnConvOpContext::run(const Tensor& input, void* output) {
   return mkldnn::internal::convolution::run(op_context_, input, output);
+}
+
+c10::intrusive_ptr<LinearOpContext> MkldnnLinearOpContext::create_context(
+    at::Tensor&& weight,
+    c10::optional<at::Tensor>&& bias,
+    std::vector<int64_t>&& input_size,
+    const ideep::attr_t& attr) {
+  auto op_context =
+      mkldnn::internal::linear::create(weight, bias, input_size, attr);
+
+  auto linear_op_context = c10::make_intrusive<MkldnnLinearOpContext>(
+      std::move(weight),
+      std::move(bias),
+      std::move(input_size),
+      std::move(op_context));
+
+  return linear_op_context;
+}
+
+Tensor MkldnnLinearOpContext::run(const Tensor& input) {
+  return mkldnn::internal::linear::run(op_context_, input);
 }
 
 } // namespace mkldnn

--- a/aten/src/ATen/native/mkldnn/OpContext.h
+++ b/aten/src/ATen/native/mkldnn/OpContext.h
@@ -93,6 +93,59 @@ class MkldnnConvOpContext final : public ConvOpContext {
       const ideep::attr_t& attr);
 };
 
+using SerializationTypeLinearPrePack = std::tuple<
+    at::Tensor,
+    c10::optional<at::Tensor>,
+    std::vector<int64_t>,
+    std::string,
+    std::vector<c10::optional<at::Scalar>>,
+    c10::optional<std::string>>;
+
+class LinearOpContext : public torch::jit::CustomClassHolder {
+ protected:
+  Tensor orig_weight_;
+  c10::optional<Tensor> orig_bias_;
+  std::vector<int64_t> input_size_;
+  std::string attr_;
+  std::vector<c10::optional<at::Scalar>> scalars_;
+  c10::optional<std::string> algorithm_;
+
+ public:
+  SerializationTypeLinearPrePack unpack() {
+    return std::make_tuple(
+        orig_weight_, orig_bias_, input_size_, attr_, scalars_, algorithm_);
+  }
+
+  virtual at::Tensor run(const at::Tensor& input) = 0;
+
+  // TODO: run with void* output
+};
+
+class MkldnnLinearOpContext final : public LinearOpContext {
+ private:
+  ContextLinear op_context_;
+
+ public:
+  MkldnnLinearOpContext(
+      Tensor&& weight,
+      c10::optional<Tensor>&& bias,
+      std::vector<int64_t>&& input_size,
+      ContextLinear&& op_context)
+      : op_context_(std::move(op_context)) {
+    orig_weight_ = std::move(weight);
+    orig_bias_ = std::move(bias);
+    input_size_ = std::move(input_size);
+  }
+
+  virtual at::Tensor run(const at::Tensor& input) override;
+
+  static c10::intrusive_ptr<LinearOpContext> create_context(
+      at::Tensor&& weight,
+      c10::optional<at::Tensor>&& bias,
+      std::vector<int64_t>&& input_size,
+      const ideep::attr_t& attr);
+};
+
 } // namespace mkldnn
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/mkldnn/OpContext.h
+++ b/aten/src/ATen/native/mkldnn/OpContext.h
@@ -118,7 +118,7 @@ class LinearOpContext : public torch::jit::CustomClassHolder {
 
   virtual at::Tensor run(const at::Tensor& input) = 0;
 
-  // TODO: run with void* output
+  virtual void run(const Tensor& input, void* output) = 0;
 };
 
 class MkldnnLinearOpContext final : public LinearOpContext {
@@ -137,7 +137,9 @@ class MkldnnLinearOpContext final : public LinearOpContext {
     input_size_ = std::move(input_size);
   }
 
-  virtual at::Tensor run(const at::Tensor& input) override;
+  at::Tensor run(const at::Tensor& input) override;
+
+  void run(const Tensor& input, void* output) override;
 
   static c10::intrusive_ptr<LinearOpContext> create_context(
       at::Tensor&& weight,

--- a/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
+++ b/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
@@ -1,5 +1,6 @@
 #include <ATen/Tensor.h>
 #include <ATen/native/mkldnn/ConvPrepack.h>
+#include <ATen/native/mkldnn/LinearPrepack.h>
 #include <ATen/native/mkldnn/OpContext.h>
 #include <torch/custom_class.h>
 #include <torch/library.h>
@@ -11,6 +12,7 @@ namespace native {
 namespace mkldnn {
 
 using namespace internal::convolution;
+using namespace internal::linear;
 
 TORCH_LIBRARY(mkldnn, m) {
   m.class_<ConvOpContext>(TORCH_SELECTIVE_CLASS("ConvOpContext"))
@@ -36,14 +38,39 @@ TORCH_LIBRARY(mkldnn, m) {
                 std::move(std::get<8>(state)),
                 std::move(std::get<9>(state)));
           });
+
+  m.class_<LinearOpContext>(TORCH_SELECTIVE_CLASS("LinearOpContext"))
+      .def_pickle(
+          [](const c10::intrusive_ptr<LinearOpContext>& op_context)
+              -> SerializationTypeLinearPrePack { // __getstate__
+            return op_context->unpack();
+          },
+          [](SerializationTypeLinearPrePack state)
+              -> c10::intrusive_ptr<LinearOpContext> { // __setstate__
+            return createLinearPrePackOpContext(
+                std::move(std::get<0>(state)),
+                std::move(std::get<1>(state)),
+                std::move(std::get<2>(state)),
+                std::move(std::get<3>(state)),
+                std::move(std::get<4>(state)),
+                std::move(std::get<5>(state)));
+          });
 }
 
 TORCH_LIBRARY(mkldnn_prepacked, m) {
+  // conv
   m.def(TORCH_SELECTIVE_SCHEMA(
       "mkldnn_prepacked::conv2d_prepack(Tensor W, Tensor? B, int[2] stride, int[2] padding, int[2] dilation, int groups, int[4] input_size, str attr, Scalar?[] scalars, str? algorithm) -> __torch__.torch.classes.mkldnn.ConvOpContext"));
 
   m.def(TORCH_SELECTIVE_SCHEMA(
       "mkldnn_prepacked::conv2d_run(Tensor X, __torch__.torch.classes.mkldnn.ConvOpContext W_prepack) -> Tensor Y"));
+
+  // linear
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "mkldnn_prepacked::linear_prepack(Tensor w, Tensor? B, int[] input_sizes, str attr, Scalar?[] scalars, str? algorithm) -> __torch__.torch.classes.mkldnn.LinearOpContext"));
+
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "mkldnn_prepacked::linear_run(Tensor X, __torch__.torch.classes.mkldnn.LinearOpContext W_prepack) -> Tensor Y"));
 }
 
 TORCH_LIBRARY_IMPL(mkldnn_prepacked, CPU, m) {
@@ -53,6 +80,14 @@ TORCH_LIBRARY_IMPL(mkldnn_prepacked, CPU, m) {
 
   m.impl(
       TORCH_SELECTIVE_NAME("mkldnn_prepacked::conv2d_run"), TORCH_FN(conv_run));
+
+  m.impl(
+      TORCH_SELECTIVE_NAME("mkldnn_prepacked::linear_prepack"),
+      TORCH_FN(createLinearPrePackOpContext));
+
+  m.impl(
+      TORCH_SELECTIVE_NAME("mkldnn_prepacked::linear_run"),
+      TORCH_FN(linear_run));
 }
 
 } // namespace mkldnn

--- a/test/test_mkldnn_fusion.py
+++ b/test/test_mkldnn_fusion.py
@@ -47,6 +47,72 @@ class TestMkldnnFusion(JitTestCase):
         torch._C._jit_set_te_must_use_llvm_cpu(old_te_must_use_llvm_cpu)
         return graph
 
+    def _eltwise_list(self):
+        eltwise_list = [
+            [torch.relu, 'aten::relu'],
+            [torch.sigmoid, 'aten::sigmoid'],
+            [torch.tanh, 'aten::tanh'],
+            [torch.nn.Hardswish(inplace=False), 'aten::hardswish'],
+            [nn.LeakyReLU(0.1, inplace=False), 'aten::leaky_relu'],
+            [nn.Hardtanh(inplace=False), 'aten::hardtanh'],
+            [nn.GELU(approximate="none"), 'aten::gelu'],
+            [nn.GELU(approximate="tanh"), 'aten::gelu'],
+        ]
+        return eltwise_list
+
+    def _clamp_modules(self):
+        class MNoOpt(nn.Module):
+            def __init__(self, m, in_channels, out_channels, bias, **kwargs):
+                super(MNoOpt, self).__init__()
+                self.conv = m(in_channels, out_channels, bias=bias, **kwargs)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = torch.clamp(x, min=-0.5, max=0.9)
+                return x
+
+        class MInf(nn.Module):
+            def __init__(self, m, in_channels, out_channels, bias, **kwargs):
+                super(MInf, self).__init__()
+                self.conv = m(in_channels, out_channels, bias=bias, **kwargs)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = torch.clamp(x, min=0, max=float('inf'))
+                return x
+
+        class MNegInf(nn.Module):
+            def __init__(self, m, in_channels, out_channels, bias, **kwargs):
+                super(MNegInf, self).__init__()
+                self.conv = m(in_channels, out_channels, bias=bias, **kwargs)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = torch.clamp(x, min=float('-inf'), max=0)
+                return x
+
+        class MOptMin(nn.Module):
+            def __init__(self, m, in_channels, out_channels, bias, **kwargs):
+                super(MOptMin, self).__init__()
+                self.conv = m(in_channels, out_channels, bias=bias, **kwargs)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = torch.clamp(x, max=2)
+                return x
+
+        class MOptMax(nn.Module):
+            def __init__(self, m, in_channels, out_channels, bias, **kwargs):
+                super(MOptMax, self).__init__()
+                self.conv = m(in_channels, out_channels, bias=bias, **kwargs)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = torch.clamp(x, min=0)
+                return x
+
+        return [MNoOpt, MInf, MNegInf, MOptMin, MOptMax]
+
     def test_single_conv(self):
         class M(nn.Module):
             def __init__(self, in_channels, out_channels, bias, **kwargs):
@@ -100,16 +166,7 @@ class TestMkldnnFusion(JitTestCase):
             [torch.contiguous_format, False],
             [torch.channels_last, True],
         ]:
-            for eltwise_fn, op_name in [
-                [torch.relu, 'aten::relu'],
-                [torch.sigmoid, 'aten::sigmoid'],
-                [torch.tanh, 'aten::tanh'],
-                [torch.nn.Hardswish(inplace=False), 'aten::hardswish'],
-                [nn.LeakyReLU(0.1, inplace=False), 'aten::leaky_relu'],
-                [nn.Hardtanh(inplace=False), 'aten::hardtanh'],
-                [nn.GELU(approximate="none"), 'aten::gelu'],
-                [nn.GELU(approximate="tanh"), 'aten::gelu'],
-            ]:
+            for eltwise_fn, op_name in self._eltwise_list():
                 for bias in [True, False]:
                     for oC in [1, 10]:
                         m = M(eltwise_fn, 3, oC, bias, kernel_size=(3, 3)).to(memory_format=memory_format)
@@ -123,57 +180,7 @@ class TestMkldnnFusion(JitTestCase):
                             self.assertGraphContains(graph, kind='aten::conv2d')
 
     def test_conv_clamp(self):
-        class MNoOpt(nn.Module):
-            def __init__(self, in_channels, out_channels, bias, **kwargs):
-                super(MNoOpt, self).__init__()
-                self.conv = torch.nn.Conv2d(in_channels, out_channels, bias=bias, **kwargs)
-
-            def forward(self, x):
-                x = self.conv(x)
-                x = torch.clamp(x, min=-0.5, max=0.9)
-                return x
-
-        class MInf(nn.Module):
-            def __init__(self, in_channels, out_channels, bias, **kwargs):
-                super(MInf, self).__init__()
-                self.conv = torch.nn.Conv2d(in_channels, out_channels, bias=bias, **kwargs)
-
-            def forward(self, x):
-                x = self.conv(x)
-                x = torch.clamp(x, min=0, max=float('inf'))
-                return x
-
-        class MNegInf(nn.Module):
-            def __init__(self, in_channels, out_channels, bias, **kwargs):
-                super(MNegInf, self).__init__()
-                self.conv = torch.nn.Conv2d(in_channels, out_channels, bias=bias, **kwargs)
-
-            def forward(self, x):
-                x = self.conv(x)
-                x = torch.clamp(x, min=float('-inf'), max=0)
-                return x
-
-        class MOptMin(nn.Module):
-            def __init__(self, in_channels, out_channels, bias, **kwargs):
-                super(MOptMin, self).__init__()
-                self.conv = torch.nn.Conv2d(in_channels, out_channels, bias=bias, **kwargs)
-
-            def forward(self, x):
-                x = self.conv(x)
-                x = torch.clamp(x, max=2)
-                return x
-
-        class MOptMax(nn.Module):
-            def __init__(self, in_channels, out_channels, bias, **kwargs):
-                super(MOptMax, self).__init__()
-                self.conv = torch.nn.Conv2d(in_channels, out_channels, bias=bias, **kwargs)
-
-            def forward(self, x):
-                x = self.conv(x)
-                x = torch.clamp(x, min=0)
-                return x
-
-        modules = [MNoOpt, MInf, MNegInf, MOptMin, MOptMax]
+        modules = self._clamp_modules()
         op_name = 'aten::clamp'
 
         for memory_format, enabled in [
@@ -182,7 +189,7 @@ class TestMkldnnFusion(JitTestCase):
         ]:
             for M in modules:
                 for bias in [True, False]:
-                    m = M(3, 10, bias, kernel_size=(3, 3)).to(memory_format=memory_format)
+                    m = M(nn.Conv2d, 3, 10, bias, kernel_size=(3, 3)).to(memory_format=memory_format)
                     x = torch.randn(1, 3, 224, 224).to(memory_format=memory_format)
 
                     graph = self._check_model(m, x)
@@ -200,7 +207,7 @@ class TestMkldnnFusion(JitTestCase):
 
             def forward(self, x):
                 res = self.linear(x)
-                return res        
+                return res
         iC = 2
         oC = 3
         for bias in [True, False]:
@@ -215,6 +222,51 @@ class TestMkldnnFusion(JitTestCase):
                 graph = self._check_model(m, x)
                 self.assertFused(graph, ['aten::linear'])
                 self.assertGraphContainsExactly(graph, FUSION_GROUP, 1)
+
+    def test_linear_eltwise(self):
+        class M(nn.Module):
+            def __init__(self, eltwise_fn, in_channels, out_channels, bias, **kwargs):
+                super(M, self).__init__()
+                self.linear = torch.nn.Linear(in_channels, out_channels, bias=bias, **kwargs)
+                self.eltwise = eltwise_fn
+
+            def forward(self, x):
+                x = self.linear(x)
+                x = self.eltwise(x)
+                return x
+        iC = 2
+        oC = 3
+        for eltwise_fn, op_name in self._eltwise_list():
+            for bias in [True, False]:
+                for x_shape in [
+                    [1, iC],
+                    [2, iC],
+                    [3, 2, iC]
+                ]:
+                    m = M(eltwise_fn, iC, oC, bias)
+                    x = torch.randn(x_shape)
+
+                    graph = self._check_model(m, x)
+                    self.assertFused(graph, ['aten::linear', 'aten::' + op_name])
+                    self.assertGraphContainsExactly(graph, FUSION_GROUP, 1)
+
+    def test_linear_clamp(self):
+        modules = self._clamp_modules()
+        op_name = 'aten::clamp'
+        iC = 2
+        oC = 3
+        for M in modules:
+            for bias in [True, False]:
+                for x_shape in [
+                    [1, iC],
+                    [2, iC],
+                    [3, 2, iC]
+                ]:
+                    m = M(nn.Linear, iC, oC, bias)
+                    x = torch.randn(x_shape)
+                    graph = self._check_model(m, x)
+                    self.assertFused(graph, ['aten::linear', 'aten::' + op_name])
+                    self.assertGraphContainsExactly(graph, FUSION_GROUP, 1)
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/csrc/jit/passes/mkldnn_rewrite.cpp
+++ b/torch/csrc/jit/passes/mkldnn_rewrite.cpp
@@ -415,7 +415,16 @@ void FuseEltwiseWithPackedOps(std::shared_ptr<Graph>& graph) {
           "%input, %weight, %bias, %stride:int[], %padding:int[], %dilation:int[], %groups:int,"),
       std::string("%weight, %bias, %stride, %padding, %dilation, %groups,"));
 
-  // TODO: add linear, matmul
+  RewriteEltwiseGraph<mkldnn::PostOp>(
+      graph,
+      mkldnn::fusion_attr_map(),
+      std::string("mkldnn_prepacked::linear_prepack"),
+      std::string("mkldnn_prepacked::linear_run"),
+      std::string("mkldnn.LinearOpContext"),
+      std::string("%input, %weight, %bias,"),
+      std::string("%weight, %bias,"));
+
+  // TODO: add matmul
 }
 
 void PrePackingOpsFolder(Block* b) {

--- a/torch/csrc/jit/passes/mkldnn_rewrite.cpp
+++ b/torch/csrc/jit/passes/mkldnn_rewrite.cpp
@@ -212,7 +212,15 @@ void insertPrePackedConvOpForNode(Node* n) {
 void insertPrePackedLinearOpForNode(Node* n) {
   constexpr int POS_INPUT = 0;
   constexpr int POS_WEIGHT = 1;
-  // TODO: check input and weight should be contiguous
+  if (!tensorexpr::isContiguous(n->input(POS_INPUT))) {
+    GRAPH_DEBUG("insertPrePackedLinearOpForNode: input is not contiguous");
+    return;
+  }
+
+  if (!tensorexpr::isContiguous(n->input(POS_WEIGHT))) {
+    GRAPH_DEBUG("insertPrePackedLinearOpForNode: weight is not contiguous");
+    return;
+  }
 
   WithInsertPoint guard(n);
   auto graph = n->owningGraph();

--- a/torch/csrc/jit/passes/mkldnn_rewrite.cpp
+++ b/torch/csrc/jit/passes/mkldnn_rewrite.cpp
@@ -209,6 +209,51 @@ void insertPrePackedConvOpForNode(Node* n) {
   n->output()->replaceAllUsesWith(prepack_conv->output());
 }
 
+void insertPrePackedLinearOpForNode(Node* n) {
+  constexpr int POS_INPUT = 0;
+  constexpr int POS_WEIGHT = 1;
+  // TODO: check input and weight should be contiguous
+
+  WithInsertPoint guard(n);
+  auto graph = n->owningGraph();
+
+  auto input_sizes = getSizesOf(n, POS_INPUT);
+  IValue input_size_value(*input_sizes.concrete_sizes());
+  auto input_size = graph->insertConstant(input_size_value);
+
+  auto prepack_node = graph->create(
+      Symbol::fromQualString("mkldnn_prepacked::linear_prepack"), 1);
+
+  // skip input value
+  for (auto i = 1; i < n->inputs().size(); i++) {
+    Value* v = n->input(i);
+    prepack_node->addInput(v);
+  }
+  prepack_node->addInput(input_size);
+  auto attr = graph->insertConstant(IValue("none"));
+  prepack_node->addInput(attr);
+
+  std::vector<c10::optional<at::Scalar>> empty_scalars;
+  auto scalars = graph->insertConstant(IValue(empty_scalars));
+  prepack_node->addInput(scalars);
+
+  c10::optional<std::string> empty_algorithm;
+  auto algorithm = graph->insertConstant(IValue(empty_algorithm));
+  prepack_node->addInput(algorithm);
+
+  prepack_node->output()->setType(
+      getCustomClass("__torch__.torch.classes.mkldnn.LinearOpContext"));
+  graph->insertNode(prepack_node);
+
+  auto prepack_linear = graph->insertNode(
+      graph->create(Symbol::fromQualString("mkldnn_prepacked::linear_run"), 1));
+  prepack_linear->addInput(n->input(0));
+  prepack_linear->addInput(prepack_node->output());
+  prepack_linear->output()->setType(n->output()->type()->cast<TensorType>());
+
+  n->output()->replaceAllUsesWith(prepack_linear->output());
+}
+
 bool isTensorTypeCPU(Node* node) {
   for (const auto& input : node->inputs()) {
     auto type = input->type()->cast<TensorType>();
@@ -241,6 +286,21 @@ void insertPrePackedConvOp(Block* b) {
   EliminateDeadCode(b);
 }
 
+void insertPrePackedLinearOp(Block* b) {
+  for (Node* n : b->nodes()) {
+    for (Block* b : n->blocks()) {
+      insertPrePackedLinearOp(b);
+    }
+
+    if (n->kind() == aten::linear) {
+      if (isTensorTypeCPU(n)) {
+        insertPrePackedLinearOpForNode(n);
+      }
+    }
+  }
+  EliminateDeadCode(b);
+}
+
 void insertMkldnnPrePackedConv2dOp(std::shared_ptr<Graph>& graph) {
   // Replace _convolution with conv2d
   graph_rewrite_helper::replaceConvolutionWithAtenConv(graph);
@@ -248,8 +308,13 @@ void insertMkldnnPrePackedConv2dOp(std::shared_ptr<Graph>& graph) {
   insertPrePackedConvOp(graph->block());
 }
 
+void insertMkldnnPrePackedLinearOp(std::shared_ptr<Graph>& graph) {
+  insertPrePackedLinearOp(graph->block());
+}
+
 void insertMkldnnPrePackedOps(std::shared_ptr<Graph>& graph) {
   insertMkldnnPrePackedConv2dOp(graph);
+  insertMkldnnPrePackedLinearOp(graph);
 }
 
 void insertMkldnnPrePackedOps(script::Module& module) {
@@ -357,7 +422,9 @@ void PrePackingOpsFolder(Block* b) {
   auto is_foldable_op = [](const Node* n) -> bool {
     return (
         n->kind() ==
-        Symbol::fromQualString("mkldnn_prepacked::conv2d_prepack"));
+            Symbol::fromQualString("mkldnn_prepacked::conv2d_prepack") ||
+        n->kind() ==
+            Symbol::fromQualString("mkldnn_prepacked::linear_prepack"));
   };
 
   std::unordered_set<Node*> nodes_to_delete;

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -81,6 +81,7 @@ static const OperatorSet& supported_non_eltwise_set() {
       "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
       "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
       "aten::matmul(Tensor self, Tensor other) -> Tensor",
+      "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
   };
   // clang-format on
   return supported_non_eltwise_set;
@@ -1055,6 +1056,12 @@ class TensorExprFuser {
     if (node->kind() == aten::matmul) {
       if (!tensorexpr::matmulIsSupported(node)) {
         GRAPH_DEBUG("Shapes of matmul inputs are not supported");
+        return false;
+      }
+    }
+    if (node->kind() == aten::linear) {
+      if (!tensorexpr::mkldnnLinearIsSupported(node)) {
+        GRAPH_DEBUG("Shapes of linear inputs are not supported");
         return false;
       }
     }

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -1060,7 +1060,7 @@ class TensorExprFuser {
       }
     }
     if (node->kind() == aten::linear) {
-      if (!tensorexpr::mkldnnLinearIsSupported(node)) {
+      if (!tensorexpr::mkldnnPrepackedLinearIsSupportedJit(node)) {
         GRAPH_DEBUG("Shapes of linear inputs are not supported");
         return false;
       }

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -1434,6 +1434,30 @@ void nnc_mkldnn_prepacked_conv_run(
   context->run(x, buf_data[0]);
 }
 
+void nnc_mkldnn_prepacked_linear_run(
+    int64_t bufs_num,
+    void** buf_data,
+    int64_t* buf_ranks,
+    int64_t* buf_dims,
+    int64_t* buf_strides,
+    int8_t* buf_dtypes,
+    int64_t args_num,
+    int64_t* extra_args) {
+  using namespace at::native::mkldnn;
+
+  auto tensors = constructTensors(
+      bufs_num - 1, buf_data, buf_ranks, buf_dims, buf_strides, buf_dtypes);
+
+  const at::Tensor& x = tensors[1];
+  auto context = reinterpret_cast<LinearOpContext*>(buf_data[2]);
+
+  at::Tensor output = context->run(x);
+  memcpy(
+      buf_data[0], output.data_ptr(), output.element_size() * output.numel());
+  // TODO: remove mem copy
+  // context->run(x, buf_data[0]);
+}
+
 #endif // AT_MKLDNN_ENABLED()
 
 #ifdef USE_XNNPACK
@@ -1618,6 +1642,10 @@ const static RegisterNNCExternalFunction nnc_embedding(
 const static RegisterNNCExternalFunction reg_nnc_mkldnn_prepacked_conv_run(
     "nnc_mkldnn_prepacked_conv_run",
     nnc_mkldnn_prepacked_conv_run);
+
+const static RegisterNNCExternalFunction reg_nnc_mkldnn_prepacked_linear_run(
+    "nnc_mkldnn_prepacked_linear_run",
+    nnc_mkldnn_prepacked_linear_run);
 #endif // AT_MKLDNN_ENABLED()
 
 #ifdef USE_XNNPACK

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -1452,10 +1452,11 @@ void nnc_mkldnn_prepacked_linear_run(
   auto context = reinterpret_cast<LinearOpContext*>(buf_data[2]);
 
   at::Tensor output = context->run(x);
-  memcpy(
-      buf_data[0], output.data_ptr(), output.element_size() * output.numel());
+  // memcpy(
+  //     buf_data[0], output.data_ptr(), output.element_size() *
+  //     output.numel());
   // TODO: remove mem copy
-  // context->run(x, buf_data[0]);
+  context->run(x, buf_data[0]);
 }
 
 #endif // AT_MKLDNN_ENABLED()

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -1452,10 +1452,6 @@ void nnc_mkldnn_prepacked_linear_run(
   auto context = reinterpret_cast<LinearOpContext*>(buf_data[2]);
 
   at::Tensor output = context->run(x);
-  // memcpy(
-  //     buf_data[0], output.data_ptr(), output.element_size() *
-  //     output.numel());
-  // TODO: remove mem copy
   context->run(x, buf_data[0]);
 }
 

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -314,6 +314,27 @@ bool mkldnnPrepackedConvIsSupportedJit(const torch::jit::Node* node) {
   return false;
 }
 
+bool mkldnnLinearIsSupported(const torch::jit::Node* node) {
+  auto const& input0 = getTensorInfoJit(node->input(0));
+  auto const& input1 = getTensorInfoJit(node->input(1));
+
+  // Everything should be statically known.
+  if (!input0 || !input1) {
+    GRAPH_DEBUG("mkldnnLinearIsSupported: Input shapes aren't static");
+    return false;
+  }
+
+  // Inputs should be contiguous, or the TE will needlessly transpose them.
+  if (!isContiguous(node->input(0)) || !isContiguous(node->input(1))) {
+    GRAPH_DEBUG("mkldnnLinearIsSupported: Input shapes are not contiguous");
+    return false;
+  }
+
+  // TODO: only support BF16 to make sure there's no performance regression
+
+  return true;
+}
+
 // The fuser currently only supports matmul of 2D x 2D matrices
 bool matmulIsSupported(const torch::jit::Node* node) {
   auto const& input0 = getTensorInfoJit(node->input(0));

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -28,7 +28,7 @@ bool conv2dIsSupportedJit(const Node* node);
 bool mkldnnPrepackedConvIsSupportedJit(const Node* node);
 // Returns true if the TE fuser supports this linear with mkldnn prepacked
 // linear.
-bool mkldnnLinearIsSupported(const Node* node);
+bool mkldnnPrepackedLinearIsSupportedJit(const Node* node);
 // Returns true if the TE fuser supports this matmul.
 bool matmulIsSupported(const Node* node);
 template <typename T>

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -26,6 +26,9 @@ struct SmallSizeTPairHash {
 bool conv2dIsSupportedJit(const Node* node);
 // Returns true if the TE fuser supports this conv2d with mkldnn prepacked conv.
 bool mkldnnPrepackedConvIsSupportedJit(const Node* node);
+// Returns true if the TE fuser supports this linear with mkldnn prepacked
+// linear.
+bool mkldnnLinearIsSupported(const Node* node);
 // Returns true if the TE fuser supports this matmul.
 bool matmulIsSupported(const Node* node);
 template <typename T>

--- a/torch/csrc/jit/tensorexpr/lowerings.cpp
+++ b/torch/csrc/jit/tensorexpr/lowerings.cpp
@@ -49,6 +49,9 @@ int nnc_lowerings_lazy_registration() {
   RegisterNNCLoweringsFunction mkldnn_prepacked_conv2d_run(
       {"mkldnn_prepacked::conv2d_run(Tensor X, __torch__.torch.classes.mkldnn.ConvOpContext W_prepack) -> (Tensor Y)"},
       computeMkldnnPrepackedConvRun);
+  RegisterNNCLoweringsFunction mkldnn_prepacked_linear_run(
+      {"mkldnn_prepacked::linear_run(Tensor X, __torch__.torch.classes.mkldnn.LinearOpContext W_prepack) -> (Tensor Y)"},
+      computeMkldnnPrepackedLinearRun);
 #endif // AT_MKLDNN_ENABLED()
 
   RegisterNNCLoweringsFunction aten_sub(

--- a/torch/csrc/jit/tensorexpr/operators/matmul.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/matmul.cpp
@@ -12,7 +12,7 @@ bool mkldnnPrepackedLinearIsSupported(
   // TODO: only support BF16 to make sure there's no performance regression
   // if (input.dtype != c10::ScalarType::BFloat16 ||
   //     weight.dtype != c10::ScalarType::BFloat16) {
-  //   GRAPH_DEBUG("conv2dIsSupported: only bfloat16 allowed");
+  //   GRAPH_DEBUG("mkldnnPrepackedLinearIsSupported: only bfloat16 allowed");
   //   return false;
   // }
   return true;

--- a/torch/csrc/jit/tensorexpr/operators/matmul.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/matmul.cpp
@@ -76,6 +76,26 @@ Tensor computeAddMM(
                inputs[4])})); // TODO: handle other dtypes of alpha and beta
 }
 
+Tensor computeMkldnnPrepackedLinearRun(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const std::vector<ExprHandle>& outputStrides,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device) {
+  Dtype dtype = kFloat;
+  if (outputType) {
+    dtype = Dtype(*outputType);
+  }
+
+  BufHandle ResultBuf(
+      "mkldnn_prepacked_linear_run", outputShape, outputStrides, dtype);
+  const BufHandle& inp = c10::get<BufHandle>(inputs[0]);
+  const BufHandle& prepacked = c10::get<BufHandle>(inputs[1]);
+  StmtPtr s = ExternalCall::make(
+      ResultBuf, "nnc_mkldnn_prepacked_linear_run", {inp, prepacked}, {});
+  return Tensor(ResultBuf.node(), s);
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/operators/matmul.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/matmul.cpp
@@ -1,9 +1,22 @@
+#include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 #include <torch/csrc/jit/tensorexpr/operators/matmul.h>
 
 namespace torch {
 namespace jit {
 namespace tensorexpr {
+
+bool mkldnnPrepackedLinearIsSupported(
+    const TensorInfo& input,
+    const TensorInfo& weight) {
+  // TODO: only support BF16 to make sure there's no performance regression
+  // if (input.dtype != c10::ScalarType::BFloat16 ||
+  //     weight.dtype != c10::ScalarType::BFloat16) {
+  //   GRAPH_DEBUG("conv2dIsSupported: only bfloat16 allowed");
+  //   return false;
+  // }
+  return true;
+}
 
 Tensor computeMatmul(
     const std::vector<ArgValue>& inputs,

--- a/torch/csrc/jit/tensorexpr/operators/matmul.h
+++ b/torch/csrc/jit/tensorexpr/operators/matmul.h
@@ -1,11 +1,15 @@
 #pragma once
 
 #include <torch/csrc/jit/tensorexpr/kernel.h>
+#include <torch/csrc/jit/tensorexpr/operators/misc.h>
 
 namespace torch {
 namespace jit {
 namespace tensorexpr {
 
+bool mkldnnPrepackedLinearIsSupported(
+    const TensorInfo& input,
+    const TensorInfo& weight);
 Tensor computeMatmul(
     const std::vector<ArgValue>& inputs,
     const std::vector<ExprHandle>& outputShape,

--- a/torch/csrc/jit/tensorexpr/operators/matmul.h
+++ b/torch/csrc/jit/tensorexpr/operators/matmul.h
@@ -18,7 +18,12 @@ Tensor computeAddMM(
     const std::vector<ExprHandle>& outputStrides,
     const c10::optional<ScalarType>& outputType,
     at::Device device);
-
+Tensor computeMkldnnPrepackedLinearRun(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const std::vector<ExprHandle>& outputStrides,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device);
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
This PR is based on the branch in https://github.com/chunyuan-w/pytorch/pull/4 which has refactored the code for the fusion part.
Added prepack OP for Linear and support the fusions with:
- relu
- sigmoid
- tanh
- hardswish (need to add new attr in ideep)
- leaky_relu
- hardtanh
- gelu
- clamp

### Add fusion of Linear with elementwise OP:
The way to enable fusion of Linear with elementwise OP becomes simpler now. `Matmul` fusion could follow the same way as below:
https://github.com/chunyuan-w/pytorch/blob/a95b1402fcc93eacf8de4740f52e2cf2aa8f07a3/torch/csrc/jit/passes/mkldnn_rewrite.cpp#L426-L433

### UT enhancement:
Add CPP UT to check that the elementwise is fused with Conv as a single operator. Linear and Matmul could follow the similar structure:
https://github.com/chunyuan-w/pytorch/blob/a95b1402fcc93eacf8de4740f52e2cf2aa8f07a3/test/cpp/tensorexpr/test_kernel.cpp#L257-L287

### TODO:
1. Dtype check
For Linear, the FP32 performance of oneDNN is sometimes worse than that of MKL. We need to add check to only rewrite the graph if the dtype is BF16. Since BF16 is not supported yet in NNC, I've commented out the dtype check for now in order to verify the functionality using FP32:
https://github.com/chunyuan-w/pytorch/blob/77dca307300ac78c00a37c594bd3151f1438b398/torch/csrc/jit/tensorexpr/operators/matmul.cpp#L9-L19

Need to enable this dtype check when this PR needs to be landed.

2. Commit history
I'll squash the commits when upstreaming this PR. Currently, I've kept the commit history since it is still in draft mode.